### PR TITLE
Set analytics URL groups

### DIFF
--- a/dev/group_vars/apim.yml
+++ b/dev/group_vars/apim.yml
@@ -68,14 +68,20 @@ deployment_mode: single # Single or HA
 
 # Enable analytics for API Manager
 analytics_enabled: false
-# Server URL of the remote StreamProcessor server used to collect statistics. Must be specified in
-# protocol://hostname:port/ format.
-stream_processor_url: "{tcp://localhost:7612}"
 stream_processor_username: ${admin.username}
 stream_processor_password: ${admin.password}
 stream_processor_rest_api_url: https://localhost:7444
 stream_processor_rest_api_username: ${admin.username}
 stream_processor_rest_api_password: ${admin.password}
+analytics_url_group:
+  - analytics_urls:
+      - tcp://analytics1.local:7612
+    analytics_auth_urls:
+      - ssl://analytics1.local:7712
+  - analytics_urls:
+      - tcp://analytics2.local:7612
+    analytics_auth_urls:
+      - ssl://analytics2.local:7712
 
 # Server URL of the Authentication service. Make sure to import the Key Manager's public certificate to WSO2 API-M's
 # client-truststore.jks. For more information, see https://docs.wso2.com/display/ADMIN44x/Creating+New+Keystores

--- a/roles/apim/templates/carbon-home/repository/conf/deployment.toml.j2
+++ b/roles/apim/templates/carbon-home/repository/conf/deployment.toml.j2
@@ -70,12 +70,18 @@ sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
 
 [apim.analytics]
 enable = "{{ analytics_enabled }}"
-receiver_urls = "{{ stream_processor_url }}"
 receiver_username = "{{ stream_processor_username }}"
 receiver_password = "{{ stream_processor_password }}"
 store_api_url = "{{ stream_processor_rest_api_url }}"
 store_api_username = "{{ stream_processor_rest_api_username }}"
 store_api_password = "{{ stream_processor_rest_api_password }}"
+
+{% for url_group in analytics_url_group %}
+[[apim.analytics.url_group]]
+analytics_url =[{% for url in url_group['analytics_urls'] %}"{{ url }}"{%- if not loop.last -%},{% endif %}{% endfor %}]
+analytics_auth_url =[{% for url in url_group['analytics_auth_urls'] %}"{{ url }}"{%- if not loop.last -%},{% endif %}{% endfor %}]
+
+{% endfor %}
 
 [apim.key_manager]
 service_url = "{{ key_manager_server_url }}"


### PR DESCRIPTION
## Goals
> Set Analytics URLs through URL groups for API Manager all-in-one

## Test environment
> Ansible 2.8.0
> Ubuntu 18.04