### PR TITLE
Adding custom keystore truststore configurations for the two roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ hs_err_pid*
 
 # Auto-generated .retry files
 *.retry
+.idea/

--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ Follow the steps mentioned under `docs` directory to customize/create new Ansibl
 
 ### 3. Including custom Keystore and Truststore
 If custom keystores and truststores are needed to be added, uncomment the below list in the yml file
-
+# security_file_list:
+#   - { src: '{{ security_file_location }}/wso2am-analytics/client-truststore.jks',
+#       dest: '{{ carbon_home }}/resources/security/client-truststore.jks' }
+#   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
+#       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
 Then save the changed file and add the required files under `files/security/<product-home>/<path-to-file>`
 
 ### 4. Customize the WSO2 Ansible scripts

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ Add the configurations to the `custom.yml`. A sample is given below.
 
 Follow the steps mentioned under `docs` directory to customize/create new Ansible scripts and deploy the recommended patterns.
 
+### 3. Including custom Keystore and Truststore
+If custom keystores and truststores are needed to be added, uncomment the below list in the yml file
+# security_file_list:
+#   - { src: '{{ security_file_location }}/wso2am-analytics/client-truststore.jks',
+#       dest: '{{ carbon_home }}/resources/security/client-truststore.jks' }
+#   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
+#       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
+
+Then save the changed file and add the required files under `files/security/<product-home>/<path-to-file>`
+
+### 4. Customize the WSO2 Ansible scripts
+
 ## Performance Tuning
 
 System configurations can be changed through Ansible to optimize OS level performance. Performance tuning can be enabled by changing `enable_performance_tuning` in `dev/group_vars/apim.yml` to `true`.

--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ Add the configurations to the `custom.yml`. A sample is given below.
 
 Follow the steps mentioned under `docs` directory to customize/create new Ansible scripts and deploy the recommended patterns.
 
-### 3. Including custom Keystore and Truststore
+#### Including custom Keystore and Truststore
 If custom keystores and truststores are needed to be added, uncomment the below list in the yml file
+```
 # security_file_list:
 #   - { src: '{{ security_file_location }}/wso2am-analytics/client-truststore.jks',
 #       dest: '{{ carbon_home }}/resources/security/client-truststore.jks' }
 #   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
+```
 Then save the changed file and add the required files under `files/security/<product-home>/<path-to-file>`
-
-### 4. Customize the WSO2 Ansible scripts
 
 ## Performance Tuning
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If custom Keystores and Truststores are needed to be added for APIM role, uncomm
 #   - { src: '{{ security_file_location }}/wso2am/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/repository/resources/security/wso2carbon.jks' }
 ```
-Then save the changed file and add the required files in the following locations:`files/security/<role-name>/<path-to-file>`
+Then save the changed file and add the required files in the following locations:`files/security/apim/<path-to-file>`
 
 ##### Adding custom Keystore and Truststore configurations APIM Analytics role
 If custom Keystores and Truststores are needed to be added for APIM Analytics role, uncomment the below list in the apim-analytics.yml file.
@@ -185,7 +185,7 @@ If custom Keystores and Truststores are needed to be added for APIM Analytics ro
 #   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
 ```
-Then save the changed file and add the required files under `files/security/<role-name>/<path-to-file>`
+Then save the changed file and add the required files under `files/security/apim-analytics/<path-to-file>`
 
 ## Performance Tuning
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If custom Keystores and Truststores are needed to be added for APIM role, uncomm
 #   - { src: '{{ security_file_location }}/wso2am/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/repository/resources/security/wso2carbon.jks' }
 ```
-Then save the changed file and add the required files in the following locations:`files/security/apim/<path-to-file>`
+Then save the changed file and add the required file to the following locations:`files/security/apim/<path-to-file>`
 
 ##### Adding custom Keystore and Truststore configurations APIM Analytics role
 If custom Keystores and Truststores are needed to be added for APIM Analytics role, uncomment the below list in the apim-analytics.yml file.
@@ -185,7 +185,7 @@ If custom Keystores and Truststores are needed to be added for APIM Analytics ro
 #   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
 ```
-Then save the changed file and add the required files under `files/security/apim-analytics/<path-to-file>`
+Then save the changed file and add the required file to the following locations:`files/security/apim-analytics/<path-to-file>`
 
 ## Performance Tuning
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Refer the below documentation on configuring key-stores for APIM and APIM-Analyt
 Refer the below documentation on configuring persistent artifacts of the servers.
 1. [Persistent artifacts of the servers](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/)
 
-Refer the below documentation on configuring Load-Balancers for your deoloyment.
+Refer the below documentation on configuring Load-Balancers for your deployment.
 1. [Load balancer configurations](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer/)
 
 ## Previous versions of Ansible

--- a/README.md
+++ b/README.md
@@ -159,11 +159,6 @@ Follow the steps mentioned under `docs` directory to customize/create new Ansibl
 
 ### 3. Including custom Keystore and Truststore
 If custom keystores and truststores are needed to be added, uncomment the below list in the yml file
-# security_file_list:
-#   - { src: '{{ security_file_location }}/wso2am-analytics/client-truststore.jks',
-#       dest: '{{ carbon_home }}/resources/security/client-truststore.jks' }
-#   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
-#       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
 
 Then save the changed file and add the required files under `files/security/<product-home>/<path-to-file>`
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,21 @@ Add the configurations to the `custom.yml`. A sample is given below.
 Follow the steps mentioned under `docs` directory to customize/create new Ansible scripts and deploy the recommended patterns.
 
 #### Including custom Keystore and Truststore
-If custom keystores and truststores are needed to be added, uncomment the below list in the yml file
+##### Adding custom Keystore and Truststore configurations APIM role
+If custom Keystores and Truststores are needed to be added for APIM role, uncomment the below list in the apim.yml file.
+(located at `dev/group_vars/apim.yml`)
+```
+# security_file_list:
+#   - { src: '{{ security_file_location }}/wso2am/client-truststore.jks',
+#       dest: '{{ carbon_home }}/repository/resources/security/client-truststore.jks' }
+#   - { src: '{{ security_file_location }}/wso2am/wso2carbon.jks',
+#       dest: '{{ carbon_home }}/repository/resources/security/wso2carbon.jks' }
+```
+Then save the changed file and add the required files in the following locations:`files/security/<role-name>/<path-to-file>`
+
+##### Adding custom Keystore and Truststore configurations APIM Analytics role
+If custom Keystores and Truststores are needed to be added for APIM Analytics role, uncomment the below list in the apim-analytics.yml file.
+(located at `dev/group_vars/apim-analytics.yml`)
 ```
 # security_file_list:
 #   - { src: '{{ security_file_location }}/wso2am-analytics/client-truststore.jks',
@@ -171,7 +185,7 @@ If custom keystores and truststores are needed to be added, uncomment the below 
 #   - { src: '{{ security_file_location }}/wso2am-analytics/wso2carbon.jks',
 #       dest: '{{ carbon_home }}/resources/security/wso2carbon.jks' }
 ```
-Then save the changed file and add the required files under `files/security/<product-home>/<path-to-file>`
+Then save the changed file and add the required files under `files/security/<role-name>/<path-to-file>`
 
 ## Performance Tuning
 


### PR DESCRIPTION
## Purpose
> This PR divide the custom Keystore and truststore configurations for the two roles Apim and Apim analytics and alleviating any confusion a reader might face

## Goals
> Improve document clarity
