### PR TITLE
Template the gateway-JWT configurations

### DIFF
--- a/dev/host_vars/apim-gateway_1.yml
+++ b/dev/host_vars/apim-gateway_1.yml
@@ -33,6 +33,17 @@ gw_memory: -Xms256m -Xmx1024m
 # If you want to add proxy port uncomment the following line
 #gw_https_proxy_port: 443 
 
+# If you want to enable 'Passing Enduser Attributes to the Backend Using JWT' feature, uncomment the following segment
+#jwt_enable: true
+#jwt_encoding: "base64" # base64,base64url
+#jwt_generator_impl: "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
+#jwt_claim_dialect: "http://wso2.org/claims"
+#jwt_convert_dialect: false
+#jwt_header: "X-JWT-Assertion"
+#jwt_signing_algorithm: "SHA256withRSA"
+#jwt_enable_user_claims: true
+#jwt_claims_extractor_impl: "org.wso2.carbon.apimgt.impl.token.ExtendedDefaultClaimsRetriever"
+
 # List of configuration file templates, and the paths they should be written to
 config_files:
   - { src: 'carbon-home/repository/conf/deployment.toml.j2',

--- a/dev/host_vars/apim-km_1.yml
+++ b/dev/host_vars/apim-km_1.yml
@@ -24,12 +24,6 @@ ports_offset: 0
 admin_username: admin
 admin_password: admin
 
-# JWT Generation
-jwt_enable: "true"
-jwt_encoding: base64
-jwt_claim_dialect: "http://wso2.org/claims"
-jwt_signing_algorithm: SHA256withRSA
-
 # If you want to add proxy port uncomment the following line
 #keymanager_https_proxy_port: 443 
 

--- a/roles/apim-gateway/templates/carbon-home/repository/conf/deployment.toml.j2
+++ b/roles/apim-gateway/templates/carbon-home/repository/conf/deployment.toml.j2
@@ -70,16 +70,19 @@ service_url = "{{ key_manager_server_url }}"
 username= "$ref{super_admin.username}"
 password= "$ref{super_admin.password}"
 
+{% if jwt_enable is defined %}
  # JWT Generation
 [apim.jwt]
-enable = true
-encoding = "base64" # base64,base64url
-#generator_impl = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
-claim_dialect = "http://wso2.org/claims"
-header = "X-JWT-Assertion"
-signing_algorithm = "SHA256withRSA"
-#enable_user_claims = true
-#claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
+enable = "{{ jwt_enable }}"
+encoding = "{{ jwt_encoding }}"
+generator_impl = "{{ jwt_generator_impl }}"
+claim_dialect = "{{ jwt_claim_dialect }}"
+convert_dialect = "{{ jwt_convert_dialect }}"
+header = "{{ jwt_header }}"
+signing_algorithm = "{{ jwt_signing_algorithm }}"
+enable_user_claims = "{{ jwt_enable_user_claims }}"
+claims_extractor_impl = "{{ jwt_claims_extractor_impl }}"
+{% endif %}
 
 [apim.throttling]
 service_url = "{{ traffic_manager_host_url }}/services/"


### PR DESCRIPTION
## Purpose
> With the current ansible scripts, by default, it is enabled the 'Passing Enduser Attributes to the Backend Using JWT' feature. To make it configurable, it is required to template the Gateway configurations.

## Goals
> With this pull request, the user will be able to decide on the 'Passing Enduser Attributes to the Backend Using JWT' feature.

## Approach
> Comment or uncomment the configurations in '<ANSIBLE_HOME>/dev/host_vars/apim-gateway_1.yml' to enable or disable the 'Passing Enduser Attributes to the Backend Using JWT' feature.

## Documentation
> https://apim.docs.wso2.com/en/latest/learn/api-gateway/passing-end-user-attributes-to-the-backend/passing-enduser-attributes-to-the-backend-using-jwt/
