### PR TITLE
Fix for #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This repository contains the Ansible scripts for installing and configuring WSO2
 
 ```
 
-Following instructions can be followed to deploy a all-in-one standard APIM deployment to tryout the product and for demonstrations purposes. If you want to deploy a production ready deployment pattern refer the documentation in the `docs` directory. 
+Following instructions can be followed to deploy a all-in-one standard APIM deployment to tryout the product and for demonstrations purposes. If you want to deploy a production ready deployment pattern refer the documentation in the `docs` directory.
 
 
 ## Copying packs locally
@@ -104,9 +104,10 @@ apim_1 ansible_host=172.28.128.4 ansible_user=vagrant
 
 Then, update the hostname in dev/host_vars/apim_1.yml with ansible_host, 172.28.128.4
 
-Run the following command to run the scripts.
+Run the following command to run the scripts. Use `-K` to provide a password to become root. Configure `become_method:` in `ansible.cfg` when using an alternative to
+`sudo`. If your host allows passwordless `sudo`, then omit the `-K` argument.
 
-`ansible-playbook -i dev site.yml`
+`ansible-playbook -K -i dev site.yml`
 
 If you need to alter the configurations given, please change the parameterized values in the yaml files under `group_vars` and `host_vars`.
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+become_method = sudo

--- a/roles/apim-control-plane/tasks/main.yml
+++ b/roles/apim-control-plane/tasks/main.yml
@@ -108,13 +108,12 @@
 
     when: "(inventory_hostname in groups['apim'])"
     become: true
-    become_method: sudo
     become_user: root
 
   - block:
     - include: common-tasks/secure-vault.yml
       when: secure_vault_enabled|bool
-      
+
     - name: Start wso2apim-controlplane as a service
       systemd:
         name: wso2apim-controlplane

--- a/roles/apim-gateway/tasks/main.yml
+++ b/roles/apim-gateway/tasks/main.yml
@@ -108,13 +108,12 @@
 
     when: "(inventory_hostname in groups['apim'])"
     become: true
-    become_method: sudo
     become_user: root
 
   - block:
     - include: common-tasks/secure-vault.yml
       when: secure_vault_enabled|bool
-      
+
     - name: Start wso2apim-gateway as a service
       systemd:
         name: wso2apim-gateway

--- a/roles/apim-tm/tasks/main.yml
+++ b/roles/apim-tm/tasks/main.yml
@@ -108,13 +108,12 @@
 
     when: "(inventory_hostname in groups['apim'])"
     become: true
-    become_method: sudo
     become_user: root
 
   - block:
     - include: common-tasks/secure-vault.yml
       when: secure_vault_enabled|bool
-      
+
     - name: Start wso2apim-tm as a service
       systemd:
         name: wso2apim-tm

--- a/roles/apim/tasks/main.yml
+++ b/roles/apim/tasks/main.yml
@@ -135,7 +135,6 @@
 
     when: "(inventory_hostname in groups['apim'])"
     become: true
-    become_method: sudo
     become_user: root
 
   - block:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,12 +18,10 @@
     - name: Create group
       group: name=wso2 state=present gid=802
       become: true
-      become_method: sudo
 
     - name: Add wso2carbon user
       user: name=wso2carbon shell=/bin/bash group=wso2 uid=802 non_unique=yes
       become: true
-      become_method: sudo
 
     - name: System performance tuning
       copy:

--- a/roles/micro-integrator/tasks/main.yml
+++ b/roles/micro-integrator/tasks/main.yml
@@ -117,7 +117,6 @@
 
     when: "(inventory_hostname in groups['micro-integrator'])"
     become: true
-    become_method: sudo
     become_user: root
 
   - block:


### PR DESCRIPTION
See bug report #98 

This PR documents the use of `ansible-playbook -K`, and it moves the redundant `become_method:` to `ansible.cfg`.